### PR TITLE
Integrate engine changes from shape-shooter

### DIFF
--- a/CollisionTester.cpp
+++ b/CollisionTester.cpp
@@ -1,5 +1,8 @@
 #include "CollisionTester.h"
 #include "Entity.h"
+#include <DirectXMath.h>
+
+using namespace DirectX;
 
 void CollisionTester::Start()
 {
@@ -11,7 +14,7 @@ void CollisionTester::Tick(float deltaTime)
 
 void CollisionTester::OnMouseDown(WPARAM buttonState, int x, int y)
 {
-	GetOwner()->GetRigidBody()->ApplyImpulse(btVector3(0, 10, 0));
+	GetOwner()->GetRigidBody()->ApplyImpulse(XMFLOAT3(0, 10, 0));
 }
 
 void CollisionTester::OnCollisionBegin(Entity* other)

--- a/RigidBodyComponent.h
+++ b/RigidBodyComponent.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "Component.h"
 #include <bullet/btBulletDynamicsCommon.h>
+#include <DirectXMath.h>
 
 // --------------------------------------------------------
 // Abstraction of Bullet physics to allow for easy
@@ -38,9 +39,9 @@ public:
 
 	// --------------------------------------------------------
 	// Applies an impulse to this Entity. 
-	// @param btVector3 force
+	// @param XMFLOAT3 impulse
 	// --------------------------------------------------------
-	void ApplyImpulse(btVector3 force);
+	void ApplyImpulse(DirectX::XMFLOAT3 impulse);
 
 
 	virtual void Start() override;


### PR DESCRIPTION
- bullet collision detection bug that occurred upon destroying entities has been fixed
- make static rigidbodies movable
- make rigidbody's ApplyImpulse use XMFLOAT3 instead of btVector3